### PR TITLE
Add Circle config for Python, Go, and Node.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,112 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    working_directory: ~/build
+    steps:
+      - run:
+          name: trigger-golang
+          command: |
+            # Trigger builds.
+            # https://circleci.com/docs/2.0/defining-multiple-jobs/#triggering-jobs
+            curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=golang \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+      - run:
+          name: trigger-nodejs
+          command: |
+            curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=nodejs \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+      - run:
+          name: trigger-python
+          command: |
+            curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=python27 \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=python36 \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+
+  golang:
+    docker:
+      - image: circleci/golang:1.8
+    working_directory: /go/src/github.com/GoogleCloudPlatform/rcloadenv
+    steps:
+      - checkout
+      - run:
+          name: extract-credentials
+          command: |
+            echo "$GOOGLE_SERVICE_KEY" | base64 --decode --ignore-garbage > "${HOME}/service-key.json"
+      - run:
+          name: system-tests
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service-key.json"
+            go get .
+            go install .
+            ./testing/run-test.sh
+
+  nodejs:
+    docker:
+      - image: circleci/node:7.10
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run:
+          name: lint
+          command: |
+            npm --prefix ./nodejs install
+            npm --prefix ./nodejs run lint
+      - run:
+          name: extract-credentials
+          command: |
+            echo "$GOOGLE_SERVICE_KEY" | base64 --decode --ignore-garbage > "${HOME}/service-key.json"
+      - run:
+          name: system-tests
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service-key.json"
+            export PATH="$PWD/nodejs/bin:$PATH"
+            ./testing/run-test.sh
+
+  python27:
+    docker:
+      - image: circleci/python:2.7
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run:
+          name: extract-credentials
+          command: |
+            echo "$GOOGLE_SERVICE_KEY" | base64 --decode --ignore-garbage > "${HOME}/service-key.json"
+      - run:
+          name: system-tests
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service-key.json"
+            pip install virtualenv
+            virtualenv venv
+            . venv/bin/activate
+            pip install -e ./python
+            ./testing/run-test.sh
+
+  python36:
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run:
+          name: extract-credentials
+          command: |
+            echo "$GOOGLE_SERVICE_KEY" | base64 --decode --ignore-garbage > "${HOME}/service-key.json"
+      - run:
+          name: system-tests
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service-key.json"
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -e ./python
+            ./testing/run-test.sh

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Use the `rcloadenv` command to launch your process.
 
     rcloadenv my-config -- bash -c 'echo $MY_VARIABLE_NAME'
 
+## Disclaimer
+
+This is not an official Google product, experimental or otherwise.
+
 ## Contributing changes
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -55,3 +59,4 @@ Use the `rcloadenv` command to launch your process.
 ## Licensing
 
 * See [LICENSE](LICENSE)
+

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -18,5 +18,8 @@
     "got": "6.7.1",
     "lodash.snakecase": "4.1.1",
     "yargs": "8.0.1"
+  },
+  "devDependencies": {
+    "semistandard": "^11.0.0"
   }
 }


### PR DESCRIPTION
Use Circle 2.0's multiple jobs feature to run builds for Python, Go, and
Node.js in parallel.

https://circleci.com/docs/2.0/defining-multiple-jobs/#triggering-jobs

It runs the system tests for each.

This could potentially be optimized further later by only triggering
builds when the corresponding folder is modified.