### PR TITLE
Ruby implementation of rcloadenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,13 @@ jobs:
                 --data build_parameters[CIRCLE_JOB]=python36 \
                 --data revision=$CIRCLE_SHA1 \
                 https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+      - run:
+          name: trigger-ruby
+          command: |
+            curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=ruby \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
 
   golang:
     docker:
@@ -109,4 +116,26 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -e ./python
+            ./testing/run-test.sh
+
+  ruby:
+    docker:
+      - image: circleci/ruby:2.4
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run:
+          name: install-dependencies
+          command: |
+            gem install bundler
+            bundle install --gemfile ruby/Gemfile
+      - run:
+          name: extract-credentials
+          command: |
+            echo "$GOOGLE_SERVICE_KEY" | base64 --decode --ignore-garbage > "${HOME}/service-key.json"
+      - run:
+          name: system-tests
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service-key.json"
+            export PATH="$PWD/ruby/bin:$PATH"
             ./testing/run-test.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Using `yarn`:
 
     yarn global add @google-cloud/rcloadenv
 
+### Ruby package
+
+Install the gem:
+
+    gem install rcloadenv
+
+Or include "rcloadenv" in your application's Gemfile.
+
 ## Usage
 
 First, create a configuration using the [Google Cloud

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,6 +54,12 @@ Install the rcloadenv Python package in editable mode.
 
         export PATH=$PATH:/path/to/rcloadenv/nodejs/bin/rcloadenv
 
+#### Ruby
+
+Temporarily add the Ruby rcloadenv binary to your path:
+
+    export PATH=/path/to/rcloadenv/ruby/bin:$PATH
+
 ### Run the test
 
     ./testing/run-test.sh

--- a/TESTING.md
+++ b/TESTING.md
@@ -56,6 +56,15 @@ Install the rcloadenv Python package in editable mode.
 
 #### Ruby
 
+Ruby 2.0 or later is required. Make sure a recent version of bundler is
+available. If not, run:
+
+    gem install bundler
+
+Make sure the gem dependencies are installed:
+
+    bundle install --gemfile=ruby/Gemfile
+
 Temporarily add the Ruby rcloadenv binary to your path:
 
     export PATH=/path/to/rcloadenv/ruby/bin:$PATH

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,0 +1,4 @@
+.yardoc/
+Gemfile.lock
+doc/
+pkg/

--- a/ruby/.yardopts
+++ b/ruby/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=RCLoadEnv
+--markup markdown
+
+./lib/rcloadenv.rb
+./lib/rcloadenv/*.rb
+-
+README.md
+CHANGELOG.md

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Ruby rcloadenv
 
-## v0.1.0 / (not yet released)
+## v0.1.0 / 2017-07-31
 
 *   Initial implementation; parallels the nodejs implementation features
     including all supported command line arguments.

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog for Ruby rcloadenv
+
+## v0.1.0 / (not yet released)
+
+*   Initial implementation; parallels the nodejs implementation features
+    including all supported command line arguments.

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Ruby rcloadenv
 
-## v0.1.0 / 2017-08-03
+## v0.1.0 / 2017-08-10
 
 *   Initial implementation; parallels the nodejs implementation features
     including all supported command line arguments.

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Ruby rcloadenv
 
-## v0.1.0 / 2017-07-31
+## v0.1.0 / 2017-08-03
 
 *   Initial implementation; parallels the nodejs implementation features
     including all supported command line arguments.

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,18 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+source 'https://rubygems.org'
+
+gemspec

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -16,8 +16,117 @@ Alternately, include "rcloadenv" in your bundle.
 You may then invoke the "rcloadenv" binary. You must pass the name of the
 runtime config resource, and then the command to execute. For example:
 
-    rcloadenv my-config -- bundle exec bin/rails s
+    bundle exec rcloadenv my-config -- bin/rails s
+
+If `rcloadenv` is run on Google Cloud Platform hosting (such as Google Compute
+Engine, Container Engine, or App Engine), then it infers the project name and
+credentials from the hosting environment.
+
+If you are not running on GCP, you may set the project using the `--project`
+switch, or by setting the `GOOGLE_CLOUD_PROJECT` environment variable. For
+example:
+
+    bundle exec rcloadenv --project=my-project my-config -- bin/rails s
+
+Run `rcloadenv --help` for more information on flags you can set.
+When not running on GCP, credentials are obtained from
+[Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
+so you can the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or
+configure `gcloud auth`.
+
+## Example: Loading the Rails SECRET_KEY_BASE in Google App Engine
+
+This gem is commonly used to provide sensitive information such as API keys or
+database passwords to a Ruby application deployed to Google Cloud Platform,
+without exposing them to configuration files checked into source control.
+
+For example, Rails applications require the environment variable
+`SECRET_KEY_BASE` to be set in the production environment. When deploying a
+Rails application to Google App Engine, you could set this environment
+variable in the "app.yaml" configuration file, but that is not recommended
+because the "app.yaml" file is commonly checked into source control. Instead,
+you can set the `SECRET_KEY_BASE` value securely in the Runtime Config
+service, and use `rcloadenv` to load it into the Rails app. Here's how.
+
+1.  We will assume that you have a [Ruby on Rails](http://rubyonrails.org/)
+    application, you have set up a
+    [Google App Engine](https://cloud.google.com/appengine/) project to deploy
+    it to, you have the [Google Cloud SDK](https://cloud.google.com/sdk/)
+    installed, and you have logged in with gcloud and set your project name in
+    the gcloud configuration.
+
+    See https://cloud.google.com/ruby for more information on deploying a
+    Ruby application to Google App Engine.
+
+2.  Enable the Runtime Config API for your project using the Google Cloud
+    Console (https://console.cloud.google.com/). To do so, navigate to
+    https://console.cloud.google.com/apis/api/runtimeconfig.googleapis.com/overview
+    choose the correct project and click "Enable".
+
+3.  Use the gcloud command line to create a Runtime Configuration:
+
+        gcloud beta runtime-config configs create my-config
+
+    Choose a name for your configuration and replace `my-config` with that
+    name. Any keys you set in this configuration will be loaded as environment
+    variables in your application.
+
+    Because you will be storing sensitive information in this configuration
+    resource, you may consider restricting access to it. See
+    https://cloud.google.com/deployment-manager/runtime-configurator/access-control
+    for more information. If you do so, make sure any service accounts that
+    run `rcloadenv` retain access to the resource. That includes the App Engine
+    service account (which runs your application in App Engine) and the
+    Cloud Build service account (which performs build steps such as asset
+    precompilation for your application).
+
+4.  Create a secret key
+
+        bundle exec rake secret
+
+    This will generate a random key and print it to the console.
+
+5.  Use the gcloud command line to set `SECRET_KEY_BASE` in your configuration.
+
+        gcloud beta runtime-config configs variables set \
+          SECRET_KEY_BASE 12345678 --config-name=my-config
+
+    Replace `my-config` with the name of your configuration, and `12345678`
+    with the secret key that you generated above.
+
+6.  Add the `rcloadenv` gem to your Gemfile, and run `bundle install` to update
+    your bundle.
+
+7.  Now set the entrypoint in your "app.yaml" configuration file to load the
+    Runtime Configuration into environment variables using `rcloadenv`. For
+    example, if entrypoint would normally be:
+
+        bundle exec bin/rails s
+
+    Then change it to:
+
+        bundle exec rcloadenv my-config -- bin/rails s
+
+    Replace `my-config` with the name of your configuration.
+
+    (If you previously set SECRET_KEY_BASE in the env_variables section of your
+    app.yaml, remove it. You no longer need it!)
+
+    Now when you deploy and run your application, it should load the
+    SECRET_KEY_BASE value from your Runtime Configuration.
+
+8.  If you have set any custom build steps for your application that require
+    this configuration, make sure you update them too. For example, you might
+    use the following to build rails assets:
+
+        bundle exec rcloadenv my-config -- rake assets:precompile
+
+You may set additional environment variables, such as database names and
+passwords, in this config as well, whether or not they are sensitive. It's a
+useful way to manage your application's configuration independent of its
+source code and config files.
 
 ## More info
 
-See https://github.com/GoogleCloudPlatform/rcloadenv for more information.
+More info can be found in the general cross-language rcloadenv README at
+https://github.com/GoogleCloudPlatform/rcloadenv

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -11,10 +11,11 @@ Install the gem using
 
     gem install rcloadenv
 
-Alternately, include "rcloadenv" in your bundle.
+Alternately, include "rcloadenv" in your application's Gemfile.
 
 You may then invoke the "rcloadenv" binary. You must pass the name of the
-runtime config resource, and then the command to execute. For example:
+runtime config resource, and then the command to execute. For example, if
+the gem is present in the bundle for your Rails app, you can execute:
 
     bundle exec rcloadenv my-config -- bin/rails s
 
@@ -29,9 +30,10 @@ example:
     bundle exec rcloadenv --project=my-project my-config -- bin/rails s
 
 Run `rcloadenv --help` for more information on flags you can set.
+
 When not running on GCP, credentials are obtained from
-[Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
-so you can the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or
+[Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials),
+so you can set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or
 configure `gcloud auth`.
 
 ## Example: Loading the Rails SECRET_KEY_BASE in Google App Engine
@@ -89,9 +91,9 @@ service, and use `rcloadenv` to load it into the Rails app. Here's how.
 5.  Use the gcloud command line to set `SECRET_KEY_BASE` in your configuration.
 
         gcloud beta runtime-config configs variables set \
-          SECRET_KEY_BASE 12345678 --config-name=my-config
+          SECRET_KEY_BASE abcd1234 --is-text --config-name=my-config
 
-    Replace `my-config` with the name of your configuration, and `12345678`
+    Replace `my-config` with the name of your configuration, and `abcd1234`
     with the secret key that you generated above.
 
 6.  Add the `rcloadenv` gem to your Gemfile, and run `bundle install` to update

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,23 @@
+# Ruby implementation of rcloadenv
+
+`rcloadenv` is a tool for loading configuration from the [Runtime Config
+API](https://cloud.google.com/deployment-manager/runtime-configurator/).
+
+This is a Ruby implementation that may be installed as a Rubygem.
+
+## Usage
+
+Install the gem using
+
+    gem install rcloadenv
+
+Alternately, include "rcloadenv" in your bundle.
+
+You may then invoke the "rcloadenv" binary. You must pass the name of the
+runtime config resource, and then the command to execute. For example:
+
+    rcloadenv my-config -- bundle exec bin/rails s
+
+## More info
+
+See https://github.com/GoogleCloudPlatform/rcloadenv for more information.

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,40 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "bundler/gem_tasks"
+require "rake/testtask"
+require "rdoc/task"
+require "yard"
+require "yard/rake/yardoc_task"
+
+CLEAN << ["pkg", "doc"]
+
+::Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = ::FileList["test/test_*.rb"]
+end
+
+::RDoc::Task.new do |rd|
+  rd.rdoc_dir = "doc"
+  rd.main = "README.md"
+  rd.rdoc_files.include "README.md", "lib/**/*.rb"
+  rd.options << "--line-numbers"
+  rd.options << "--all"
+end
+
+::YARD::Rake::YardocTask.new
+
+task :default => [:test]

--- a/ruby/bin/rcloadenv
+++ b/ruby/bin/rcloadenv
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+begin
+  require "rcloadenv"
+rescue LoadError
+  # If the gem is not installed, attempt to use the library from local source
+  # (i.e. for local testing).
+  path = File.dirname ::File.dirname __FILE__
+  path = File.join path, "lib"
+  $:.unshift path
+  require "rcloadenv"
+end
+
+cli = RCLoadEnv::CLI.new $0, ARGV
+cli.run

--- a/ruby/bin/rcloadenv
+++ b/ruby/bin/rcloadenv
@@ -25,5 +25,5 @@ rescue LoadError
   require "rcloadenv"
 end
 
-cli = RCLoadEnv::CLI.new $0, ARGV
+cli = RCLoadEnv::CLI.new ARGV
 cli.run

--- a/ruby/lib/rcloadenv.rb
+++ b/ruby/lib/rcloadenv.rb
@@ -1,0 +1,30 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "optparse"
+
+##
+# # Ruby implementation of rcloadenv
+#
+# See https://github.com/GoogleCloudPlatform/rcloadenv for more information
+# on this tool.
+#
+module RCLoadEnv
+end
+
+require "rcloadenv/cli"
+require "rcloadenv/credentials"
+require "rcloadenv/loader"
+require "rcloadenv/version"

--- a/ruby/lib/rcloadenv/api_client.rb
+++ b/ruby/lib/rcloadenv/api_client.rb
@@ -1,0 +1,24 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+# As of google-api-client 0.13.1 (July 2017) there isn't a client for
+# RuntimeConfig V1beta1, but there might be in the future. So first we attempt
+# to load a client from google-api-client, but if it doesn't exist, we use
+# a vendored client we generated on 2017-07-19.
+begin
+  require "google/apis/runtimeconfig_v1beta1"
+rescue LoadError
+  require "rcloadenv/google/apis/runtimeconfig_v1beta1"
+end

--- a/ruby/lib/rcloadenv/cli.rb
+++ b/ruby/lib/rcloadenv/cli.rb
@@ -1,0 +1,123 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "optparse"
+
+module RCLoadEnv
+
+  ##
+  # Implementation of the rcloadenv command line.
+  #
+  class CLI
+
+    ##
+    # Create a command line handler.
+    #
+    # @param [String] invocation The rcloadenv binary invoked.
+    # @param [Array<String>] args Command-line arguments
+    #
+    def initialize invocation, args
+      @invocation = invocation
+      @args = args
+      @project = nil
+      @exclude = []
+      @include = []
+      @override = false
+      @debug = false
+      @disable_bundler = false
+      parser = OptionParser.new do |opts|
+        opts.banner = "Usage: rcloadenv [options] <config-name> -- <command>"
+        opts.on "-p name", "--project=name", "--projectId=name",
+                "Project to read runtime config from" do |p|
+          @project = p
+        end
+        opts.on "-E key1,key2,key3", "--except=key1,key2,key3",
+                "Runtime-config variables to exclude, comma delimited" do |v|
+          @exclude += v.split ","
+        end
+        opts.on "-O key1,key2,key3", "--only=key1,key2,key3",
+                "Runtime-config variables to include, comma delimited" do |v|
+          @include += v.split ","
+        end
+        opts.on "-o", "--override",
+                "Cause config to override existing environment variables" do
+          @override = true
+        end
+        opts.on "-d", "--debug", "Enable debug output" do
+          @debug = true
+        end
+        opts.on "-B", "--disable-bundler", "Disable auto bundle exec" do
+          @disable_bundler = true
+        end
+        opts.on "-?", "--help", "Show the help text and exit" do
+          puts parser.help
+          exit
+        end
+      end
+      @command_list = parser.parse args
+      @config_name = @command_list.shift
+      unless @config_name && @command_list.size > 0
+        STDERR.puts "rcloadenv: config name and command are both required."
+        STDERR.puts parser.help
+        exit 1
+      end
+    end
+
+    ##
+    # Run the command line handler. This will rewrap the invocation in
+    # `bundle exec` if needed. This method either never returns or throws
+    # an exception.
+    #
+    def run
+      execute if @disable_bundler
+      execute unless ENV["BUNDLE_GEMFILE"].to_s.empty?
+      execute unless bundler_exists?
+      execute unless gemfile_exists?
+      if @debug
+        puts "Rerunning rcloadenv under bundle exec. Pass -B to disable this."
+      end
+      exec "bundle", "exec", @invocation, "-B", *@args
+    end
+
+    ##
+    # Determine whether bundler appears to be present
+    # @private
+    #
+    def bundler_exists?
+      `bundle version`
+      $?.exitstatus == 0
+    end
+
+    ##
+    # Determine whether there is a Gemfile
+    # @private
+    #
+    def gemfile_exists?
+      File.readable? "Gemfile"
+    end
+
+    ##
+    # Load the runtime config and execute the command. Never returns.
+    # @private
+    #
+    def execute
+      loader = RCLoadEnv::Loader.new @config_name,
+          exclude: @exclude, include: @include, override: @override,
+          project: @project, debug: @debug
+      loader.modify_env ENV
+      exec *@command_list
+    end
+  end
+end

--- a/ruby/lib/rcloadenv/credentials.rb
+++ b/ruby/lib/rcloadenv/credentials.rb
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "rcloadenv/api_client"
+require "google/cloud/credentials"
+
+module RCLoadEnv
+  ##
+  # @private Represents the OAuth 2.0 signing logic for Runtime Config.
+  #
+  class Credentials < Google::Cloud::Credentials
+    SCOPE = [Google::Apis::RuntimeconfigV1beta1::AUTH_CLOUDRUNTIMECONFIG]
+    PATH_ENV_VARS = %w(GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+    JSON_ENV_VARS = %w(GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+  end
+end

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1.rb
@@ -1,0 +1,44 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note this is a vendored copy of this class, generated 2017-07-19 alongside
+# google-api-client 0.13.1.
+
+# Vendored location: "rcloadenv/google/apis/runtimeconfig_v1beta1"
+require 'rcloadenv/google/apis/runtimeconfig_v1beta1/service.rb'
+require 'rcloadenv/google/apis/runtimeconfig_v1beta1/classes.rb'
+require 'rcloadenv/google/apis/runtimeconfig_v1beta1/representations.rb'
+
+module Google
+  module Apis
+    # Google Cloud Runtime Configuration API
+    #
+    # The Runtime Configurator allows you to dynamically configure and expose
+    # variables through Google Cloud Platform. In addition, you can also set
+    # Watchers and Waiters that will watch for changes to your data and return based
+    # on certain conditions.
+    #
+    # @see https://cloud.google.com/deployment-manager/runtime-configurator/
+    module RuntimeconfigV1beta1
+      VERSION = 'V1beta1'
+      REVISION = '20170620'
+
+      # View and manage your data across Google Cloud Platform services
+      AUTH_CLOUD_PLATFORM = 'https://www.googleapis.com/auth/cloud-platform'
+
+      # Manage your Google Cloud Platform services' runtime configuration
+      AUTH_CLOUDRUNTIMECONFIG = 'https://www.googleapis.com/auth/cloudruntimeconfig'
+    end
+  end
+end

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/classes.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/classes.rb
@@ -1,0 +1,805 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'date'
+require 'google/apis/core/base_service'
+require 'google/apis/core/json_representation'
+require 'google/apis/core/hashable'
+require 'google/apis/errors'
+
+module Google
+  module Apis
+    module RuntimeconfigV1beta1
+      
+      # Request message for `SetIamPolicy` method.
+      class SetIamPolicyRequest
+        include Google::Apis::Core::Hashable
+      
+        # Defines an Identity and Access Management (IAM) policy. It is used to
+        # specify access control policies for Cloud Platform resources.
+        # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+        # `members` to a `role`, where the members can be user accounts, Google groups,
+        # Google domains, and service accounts. A `role` is a named list of permissions
+        # defined by IAM.
+        # **Example**
+        # `
+        # "bindings": [
+        # `
+        # "role": "roles/owner",
+        # "members": [
+        # "user:mike@example.com",
+        # "group:admins@example.com",
+        # "domain:google.com",
+        # "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+        # ]
+        # `,
+        # `
+        # "role": "roles/viewer",
+        # "members": ["user:sean@example.com"]
+        # `
+        # ]
+        # `
+        # For a description of IAM and its features, see the
+        # [IAM developer's guide](https://cloud.google.com/iam).
+        # Corresponds to the JSON property `policy`
+        # @return [Google::Apis::RuntimeconfigV1beta1::Policy]
+        attr_accessor :policy
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @policy = args[:policy] if args.key?(:policy)
+        end
+      end
+      
+      # The `Status` type defines a logical error model that is suitable for different
+      # programming environments, including REST APIs and RPC APIs. It is used by
+      # [gRPC](https://github.com/grpc). The error model is designed to be:
+      # - Simple to use and understand for most users
+      # - Flexible enough to meet unexpected needs
+      # # Overview
+      # The `Status` message contains three pieces of data: error code, error message,
+      # and error details. The error code should be an enum value of
+      # google.rpc.Code, but it may accept additional error codes if needed.  The
+      # error message should be a developer-facing English message that helps
+      # developers *understand* and *resolve* the error. If a localized user-facing
+      # error message is needed, put the localized message in the error details or
+      # localize it in the client. The optional error details may contain arbitrary
+      # information about the error. There is a predefined set of error detail types
+      # in the package `google.rpc` that can be used for common error conditions.
+      # # Language mapping
+      # The `Status` message is the logical representation of the error model, but it
+      # is not necessarily the actual wire format. When the `Status` message is
+      # exposed in different client libraries and different wire protocols, it can be
+      # mapped differently. For example, it will likely be mapped to some exceptions
+      # in Java, but more likely mapped to some error codes in C.
+      # # Other uses
+      # The error model and the `Status` message can be used in a variety of
+      # environments, either with or without APIs, to provide a
+      # consistent developer experience across different environments.
+      # Example uses of this error model include:
+      # - Partial errors. If a service needs to return partial errors to the client,
+      # it may embed the `Status` in the normal response to indicate the partial
+      # errors.
+      # - Workflow errors. A typical workflow has multiple steps. Each step may
+      # have a `Status` message for error reporting.
+      # - Batch operations. If a client uses batch request and batch response, the
+      # `Status` message should be used directly inside batch response, one for
+      # each error sub-response.
+      # - Asynchronous operations. If an API call embeds asynchronous operation
+      # results in its response, the status of those operations should be
+      # represented directly using the `Status` message.
+      # - Logging. If some API errors are stored in logs, the message `Status` could
+      # be used directly after any stripping needed for security/privacy reasons.
+      class Status
+        include Google::Apis::Core::Hashable
+      
+        # A list of messages that carry the error details.  There will be a
+        # common set of message types for APIs to use.
+        # Corresponds to the JSON property `details`
+        # @return [Array<Hash<String,Object>>]
+        attr_accessor :details
+      
+        # The status code, which should be an enum value of google.rpc.Code.
+        # Corresponds to the JSON property `code`
+        # @return [Fixnum]
+        attr_accessor :code
+      
+        # A developer-facing error message, which should be in English. Any
+        # user-facing error message should be localized and sent in the
+        # google.rpc.Status.details field, or localized by the client.
+        # Corresponds to the JSON property `message`
+        # @return [String]
+        attr_accessor :message
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @details = args[:details] if args.key?(:details)
+          @code = args[:code] if args.key?(:code)
+          @message = args[:message] if args.key?(:message)
+        end
+      end
+      
+      # Associates `members` with a `role`.
+      class Binding
+        include Google::Apis::Core::Hashable
+      
+        # Specifies the identities requesting access for a Cloud Platform resource.
+        # `members` can have the following values:
+        # * `allUsers`: A special identifier that represents anyone who is
+        # on the internet; with or without a Google account.
+        # * `allAuthenticatedUsers`: A special identifier that represents anyone
+        # who is authenticated with a Google account or a service account.
+        # * `user:`emailid``: An email address that represents a specific Google
+        # account. For example, `alice@gmail.com` or `joe@example.com`.
+        # * `serviceAccount:`emailid``: An email address that represents a service
+        # account. For example, `my-other-app@appspot.gserviceaccount.com`.
+        # * `group:`emailid``: An email address that represents a Google group.
+        # For example, `admins@example.com`.
+        # * `domain:`domain``: A Google Apps domain name that represents all the
+        # users of that domain. For example, `google.com` or `example.com`.
+        # Corresponds to the JSON property `members`
+        # @return [Array<String>]
+        attr_accessor :members
+      
+        # Role that is assigned to `members`.
+        # For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
+        # Required
+        # Corresponds to the JSON property `role`
+        # @return [String]
+        attr_accessor :role
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @members = args[:members] if args.key?(:members)
+          @role = args[:role] if args.key?(:role)
+        end
+      end
+      
+      # A generic empty message that you can re-use to avoid defining duplicated
+      # empty messages in your APIs. A typical example is to use it as the request
+      # or the response type of an API method. For instance:
+      # service Foo `
+      # rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+      # `
+      # The JSON representation for `Empty` is empty JSON object ````.
+      class Empty
+        include Google::Apis::Core::Hashable
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+        end
+      end
+      
+      # A Cardinality condition for the Waiter resource. A cardinality condition is
+      # met when the number of variables under a specified path prefix reaches a
+      # predefined number. For example, if you set a Cardinality condition where
+      # the `path` is set to `/foo` and the number of paths is set to 2, the
+      # following variables would meet the condition in a RuntimeConfig resource:
+      # + `/foo/variable1 = "value1"`
+      # + `/foo/variable2 = "value2"`
+      # + `/bar/variable3 = "value3"`
+      # It would not would not satisify the same condition with the `number` set to
+      # 3, however, because there is only 2 paths that start with `/foo`.
+      # Cardinality conditions are recursive; all subtrees under the specific
+      # path prefix are counted.
+      class Cardinality
+        include Google::Apis::Core::Hashable
+      
+        # The number variables under the `path` that must exist to meet this
+        # condition. Defaults to 1 if not specified.
+        # Corresponds to the JSON property `number`
+        # @return [Fixnum]
+        attr_accessor :number
+      
+        # The root of the variable subtree to monitor. For example, `/foo`.
+        # Corresponds to the JSON property `path`
+        # @return [String]
+        attr_accessor :path
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @number = args[:number] if args.key?(:number)
+          @path = args[:path] if args.key?(:path)
+        end
+      end
+      
+      # `ListConfigs()` returns the following response. The order of returned
+      # objects is arbitrary; that is, it is not ordered in any particular way.
+      class ListConfigsResponse
+        include Google::Apis::Core::Hashable
+      
+        # A list of the configurations in the project. The order of returned
+        # objects is arbitrary; that is, it is not ordered in any particular way.
+        # Corresponds to the JSON property `configs`
+        # @return [Array<Google::Apis::RuntimeconfigV1beta1::RuntimeConfig>]
+        attr_accessor :configs
+      
+        # This token allows you to get the next page of results for list requests.
+        # If the number of results is larger than `pageSize`, use the `nextPageToken`
+        # as a value for the query parameter `pageToken` in the next list request.
+        # Subsequent list requests will have their own `nextPageToken` to continue
+        # paging through the results
+        # Corresponds to the JSON property `nextPageToken`
+        # @return [String]
+        attr_accessor :next_page_token
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @configs = args[:configs] if args.key?(:configs)
+          @next_page_token = args[:next_page_token] if args.key?(:next_page_token)
+        end
+      end
+      
+      # The condition that a Waiter resource is waiting for.
+      class EndCondition
+        include Google::Apis::Core::Hashable
+      
+        # A Cardinality condition for the Waiter resource. A cardinality condition is
+        # met when the number of variables under a specified path prefix reaches a
+        # predefined number. For example, if you set a Cardinality condition where
+        # the `path` is set to `/foo` and the number of paths is set to 2, the
+        # following variables would meet the condition in a RuntimeConfig resource:
+        # + `/foo/variable1 = "value1"`
+        # + `/foo/variable2 = "value2"`
+        # + `/bar/variable3 = "value3"`
+        # It would not would not satisify the same condition with the `number` set to
+        # 3, however, because there is only 2 paths that start with `/foo`.
+        # Cardinality conditions are recursive; all subtrees under the specific
+        # path prefix are counted.
+        # Corresponds to the JSON property `cardinality`
+        # @return [Google::Apis::RuntimeconfigV1beta1::Cardinality]
+        attr_accessor :cardinality
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @cardinality = args[:cardinality] if args.key?(:cardinality)
+        end
+      end
+      
+      # Response message for `TestIamPermissions` method.
+      class TestIamPermissionsResponse
+        include Google::Apis::Core::Hashable
+      
+        # A subset of `TestPermissionsRequest.permissions` that the caller is
+        # allowed.
+        # Corresponds to the JSON property `permissions`
+        # @return [Array<String>]
+        attr_accessor :permissions
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @permissions = args[:permissions] if args.key?(:permissions)
+        end
+      end
+      
+      # Response for the `ListVariables()` method.
+      class ListVariablesResponse
+        include Google::Apis::Core::Hashable
+      
+        # This token allows you to get the next page of results for list requests.
+        # If the number of results is larger than `pageSize`, use the `nextPageToken`
+        # as a value for the query parameter `pageToken` in the next list request.
+        # Subsequent list requests will have their own `nextPageToken` to continue
+        # paging through the results
+        # Corresponds to the JSON property `nextPageToken`
+        # @return [String]
+        attr_accessor :next_page_token
+      
+        # A list of variables and their values. The order of returned variable
+        # objects is arbitrary.
+        # Corresponds to the JSON property `variables`
+        # @return [Array<Google::Apis::RuntimeconfigV1beta1::Variable>]
+        attr_accessor :variables
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @next_page_token = args[:next_page_token] if args.key?(:next_page_token)
+          @variables = args[:variables] if args.key?(:variables)
+        end
+      end
+      
+      # A RuntimeConfig resource is the primary resource in the Cloud RuntimeConfig
+      # service. A RuntimeConfig resource consists of metadata and a hierarchy of
+      # variables.
+      class RuntimeConfig
+        include Google::Apis::Core::Hashable
+      
+        # The resource name of a runtime config. The name must have the format:
+        # projects/[PROJECT_ID]/configs/[CONFIG_NAME]
+        # The `[PROJECT_ID]` must be a valid project ID, and `[CONFIG_NAME]` is an
+        # arbitrary name that matches RFC 1035 segment specification. The length of
+        # `[CONFIG_NAME]` must be less than 64 bytes.
+        # You pick the RuntimeConfig resource name, but the server will validate that
+        # the name adheres to this format. After you create the resource, you cannot
+        # change the resource's name.
+        # Corresponds to the JSON property `name`
+        # @return [String]
+        attr_accessor :name
+      
+        # An optional description of the RuntimeConfig object.
+        # Corresponds to the JSON property `description`
+        # @return [String]
+        attr_accessor :description
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @name = args[:name] if args.key?(:name)
+          @description = args[:description] if args.key?(:description)
+        end
+      end
+      
+      # Request for the `WatchVariable()` method.
+      class WatchVariableRequest
+        include Google::Apis::Core::Hashable
+      
+        # If specified, checks the current timestamp of the variable and if the
+        # current timestamp is newer than `newerThan` timestamp, the method returns
+        # immediately.
+        # If not specified or the variable has an older timestamp, the watcher waits
+        # for a the value to change before returning.
+        # Corresponds to the JSON property `newerThan`
+        # @return [String]
+        attr_accessor :newer_than
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @newer_than = args[:newer_than] if args.key?(:newer_than)
+        end
+      end
+      
+      # Response for the `ListWaiters()` method.
+      # Order of returned waiter objects is arbitrary.
+      class ListWaitersResponse
+        include Google::Apis::Core::Hashable
+      
+        # This token allows you to get the next page of results for list requests.
+        # If the number of results is larger than `pageSize`, use the `nextPageToken`
+        # as a value for the query parameter `pageToken` in the next list request.
+        # Subsequent list requests will have their own `nextPageToken` to continue
+        # paging through the results
+        # Corresponds to the JSON property `nextPageToken`
+        # @return [String]
+        attr_accessor :next_page_token
+      
+        # Found waiters in the project.
+        # Corresponds to the JSON property `waiters`
+        # @return [Array<Google::Apis::RuntimeconfigV1beta1::Waiter>]
+        attr_accessor :waiters
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @next_page_token = args[:next_page_token] if args.key?(:next_page_token)
+          @waiters = args[:waiters] if args.key?(:waiters)
+        end
+      end
+      
+      # Request message for `TestIamPermissions` method.
+      class TestIamPermissionsRequest
+        include Google::Apis::Core::Hashable
+      
+        # The set of permissions to check for the `resource`. Permissions with
+        # wildcards (such as '*' or 'storage.*') are not allowed. For more
+        # information see
+        # [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        # Corresponds to the JSON property `permissions`
+        # @return [Array<String>]
+        attr_accessor :permissions
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @permissions = args[:permissions] if args.key?(:permissions)
+        end
+      end
+      
+      # A Waiter resource waits for some end condition within a RuntimeConfig resource
+      # to be met before it returns. For example, assume you have a distributed
+      # system where each node writes to a Variable resource indidicating the node's
+      # readiness as part of the startup process.
+      # You then configure a Waiter resource with the success condition set to wait
+      # until some number of nodes have checked in. Afterwards, your application
+      # runs some arbitrary code after the condition has been met and the waiter
+      # returns successfully.
+      # Once created, a Waiter resource is immutable.
+      # To learn more about using waiters, read the
+      # [Creating a Waiter](/deployment-manager/runtime-configurator/creating-a-waiter)
+      # documentation.
+      class Waiter
+        include Google::Apis::Core::Hashable
+      
+        # The `Status` type defines a logical error model that is suitable for different
+        # programming environments, including REST APIs and RPC APIs. It is used by
+        # [gRPC](https://github.com/grpc). The error model is designed to be:
+        # - Simple to use and understand for most users
+        # - Flexible enough to meet unexpected needs
+        # # Overview
+        # The `Status` message contains three pieces of data: error code, error message,
+        # and error details. The error code should be an enum value of
+        # google.rpc.Code, but it may accept additional error codes if needed.  The
+        # error message should be a developer-facing English message that helps
+        # developers *understand* and *resolve* the error. If a localized user-facing
+        # error message is needed, put the localized message in the error details or
+        # localize it in the client. The optional error details may contain arbitrary
+        # information about the error. There is a predefined set of error detail types
+        # in the package `google.rpc` that can be used for common error conditions.
+        # # Language mapping
+        # The `Status` message is the logical representation of the error model, but it
+        # is not necessarily the actual wire format. When the `Status` message is
+        # exposed in different client libraries and different wire protocols, it can be
+        # mapped differently. For example, it will likely be mapped to some exceptions
+        # in Java, but more likely mapped to some error codes in C.
+        # # Other uses
+        # The error model and the `Status` message can be used in a variety of
+        # environments, either with or without APIs, to provide a
+        # consistent developer experience across different environments.
+        # Example uses of this error model include:
+        # - Partial errors. If a service needs to return partial errors to the client,
+        # it may embed the `Status` in the normal response to indicate the partial
+        # errors.
+        # - Workflow errors. A typical workflow has multiple steps. Each step may
+        # have a `Status` message for error reporting.
+        # - Batch operations. If a client uses batch request and batch response, the
+        # `Status` message should be used directly inside batch response, one for
+        # each error sub-response.
+        # - Asynchronous operations. If an API call embeds asynchronous operation
+        # results in its response, the status of those operations should be
+        # represented directly using the `Status` message.
+        # - Logging. If some API errors are stored in logs, the message `Status` could
+        # be used directly after any stripping needed for security/privacy reasons.
+        # Corresponds to the JSON property `error`
+        # @return [Google::Apis::RuntimeconfigV1beta1::Status]
+        attr_accessor :error
+      
+        # The condition that a Waiter resource is waiting for.
+        # Corresponds to the JSON property `failure`
+        # @return [Google::Apis::RuntimeconfigV1beta1::EndCondition]
+        attr_accessor :failure
+      
+        # The condition that a Waiter resource is waiting for.
+        # Corresponds to the JSON property `success`
+        # @return [Google::Apis::RuntimeconfigV1beta1::EndCondition]
+        attr_accessor :success
+      
+        # [Output Only] If the value is `false`, it means the waiter is still waiting
+        # for one of its conditions to be met.
+        # If true, the waiter has finished. If the waiter finished due to a timeout
+        # or failure, `error` will be set.
+        # Corresponds to the JSON property `done`
+        # @return [Boolean]
+        attr_accessor :done
+        alias_method :done?, :done
+      
+        # [Output Only] The instant at which this Waiter resource was created. Adding
+        # the value of `timeout` to this instant yields the timeout deadline for the
+        # waiter.
+        # Corresponds to the JSON property `createTime`
+        # @return [String]
+        attr_accessor :create_time
+      
+        # [Required] Specifies the timeout of the waiter in seconds, beginning from
+        # the instant that `waiters().create` method is called. If this time elapses
+        # before the success or failure conditions are met, the waiter fails and sets
+        # the `error` code to `DEADLINE_EXCEEDED`.
+        # Corresponds to the JSON property `timeout`
+        # @return [String]
+        attr_accessor :timeout
+      
+        # The name of the Waiter resource, in the format:
+        # projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]
+        # The `[PROJECT_ID]` must be a valid Google Cloud project ID,
+        # the `[CONFIG_NAME]` must be a valid RuntimeConfig resource, the
+        # `[WAITER_NAME]` must match RFC 1035 segment specification, and the length
+        # of `[WAITER_NAME]` must be less than 64 bytes.
+        # After you create a Waiter resource, you cannot change the resource name.
+        # Corresponds to the JSON property `name`
+        # @return [String]
+        attr_accessor :name
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @error = args[:error] if args.key?(:error)
+          @failure = args[:failure] if args.key?(:failure)
+          @success = args[:success] if args.key?(:success)
+          @done = args[:done] if args.key?(:done)
+          @create_time = args[:create_time] if args.key?(:create_time)
+          @timeout = args[:timeout] if args.key?(:timeout)
+          @name = args[:name] if args.key?(:name)
+        end
+      end
+      
+      # Defines an Identity and Access Management (IAM) policy. It is used to
+      # specify access control policies for Cloud Platform resources.
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
+      # defined by IAM.
+      # **Example**
+      # `
+      # "bindings": [
+      # `
+      # "role": "roles/owner",
+      # "members": [
+      # "user:mike@example.com",
+      # "group:admins@example.com",
+      # "domain:google.com",
+      # "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+      # ]
+      # `,
+      # `
+      # "role": "roles/viewer",
+      # "members": ["user:sean@example.com"]
+      # `
+      # ]
+      # `
+      # For a description of IAM and its features, see the
+      # [IAM developer's guide](https://cloud.google.com/iam).
+      class Policy
+        include Google::Apis::Core::Hashable
+      
+        # `etag` is used for optimistic concurrency control as a way to help
+        # prevent simultaneous updates of a policy from overwriting each other.
+        # It is strongly suggested that systems make use of the `etag` in the
+        # read-modify-write cycle to perform policy updates in order to avoid race
+        # conditions: An `etag` is returned in the response to `getIamPolicy`, and
+        # systems are expected to put that etag in the request to `setIamPolicy` to
+        # ensure that their change will be applied to the same version of the policy.
+        # If no `etag` is provided in the call to `setIamPolicy`, then the existing
+        # policy is overwritten blindly.
+        # Corresponds to the JSON property `etag`
+        # NOTE: Values are automatically base64 encoded/decoded in the client library.
+        # @return [String]
+        attr_accessor :etag
+      
+        # Version of the `Policy`. The default version is 0.
+        # Corresponds to the JSON property `version`
+        # @return [Fixnum]
+        attr_accessor :version
+      
+        # Associates a list of `members` to a `role`.
+        # `bindings` with no members will result in an error.
+        # Corresponds to the JSON property `bindings`
+        # @return [Array<Google::Apis::RuntimeconfigV1beta1::Binding>]
+        attr_accessor :bindings
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @etag = args[:etag] if args.key?(:etag)
+          @version = args[:version] if args.key?(:version)
+          @bindings = args[:bindings] if args.key?(:bindings)
+        end
+      end
+      
+      # Describes a single variable within a RuntimeConfig resource.
+      # The name denotes the hierarchical variable name. For example,
+      # `ports/serving_port` is a valid variable name. The variable value is an
+      # opaque string and only leaf variables can have values (that is, variables
+      # that do not have any child variables).
+      class Variable
+        include Google::Apis::Core::Hashable
+      
+        # The binary value of the variable. The length of the value must be less
+        # than 4096 bytes. Empty values are also accepted. The value must be
+        # base64 encoded. Only one of `value` or `text` can be set.
+        # Corresponds to the JSON property `value`
+        # NOTE: Values are automatically base64 encoded/decoded in the client library.
+        # @return [String]
+        attr_accessor :value
+      
+        # [Ouput only] The current state of the variable. The variable state indicates
+        # the outcome of the `variables().watch` call and is visible through the
+        # `get` and `list` calls.
+        # Corresponds to the JSON property `state`
+        # @return [String]
+        attr_accessor :state
+      
+        # [Output Only] The time of the last variable update.
+        # Corresponds to the JSON property `updateTime`
+        # @return [String]
+        attr_accessor :update_time
+      
+        # The name of the variable resource, in the format:
+        # projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]
+        # The `[PROJECT_ID]` must be a valid project ID, `[CONFIG_NAME]` must be a
+        # valid RuntimeConfig reource and `[VARIABLE_NAME]` follows Unix file system
+        # file path naming.
+        # The `[VARIABLE_NAME]` can contain ASCII letters, numbers, slashes and
+        # dashes. Slashes are used as path element separators and are not part of the
+        # `[VARIABLE_NAME]` itself, so `[VARIABLE_NAME]` must contain at least one
+        # non-slash character. Multiple slashes are coalesced into single slash
+        # character. Each path segment should follow RFC 1035 segment specification.
+        # The length of a `[VARIABLE_NAME]` must be less than 256 bytes.
+        # Once you create a variable, you cannot change the variable name.
+        # Corresponds to the JSON property `name`
+        # @return [String]
+        attr_accessor :name
+      
+        # The string value of the variable. The length of the value must be less
+        # than 4096 bytes. Empty values are also accepted. For example,
+        # `text: "my text value"`. The string must be valid UTF-8.
+        # Corresponds to the JSON property `text`
+        # @return [String]
+        attr_accessor :text
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @value = args[:value] if args.key?(:value)
+          @state = args[:state] if args.key?(:state)
+          @update_time = args[:update_time] if args.key?(:update_time)
+          @name = args[:name] if args.key?(:name)
+          @text = args[:text] if args.key?(:text)
+        end
+      end
+      
+      # This resource represents a long-running operation that is the result of a
+      # network API call.
+      class Operation
+        include Google::Apis::Core::Hashable
+      
+        # Service-specific metadata associated with the operation.  It typically
+        # contains progress information and common metadata such as create time.
+        # Some services might not provide such metadata.  Any method that returns a
+        # long-running operation should document the metadata type, if any.
+        # Corresponds to the JSON property `metadata`
+        # @return [Hash<String,Object>]
+        attr_accessor :metadata
+      
+        # If the value is `false`, it means the operation is still in progress.
+        # If true, the operation is completed, and either `error` or `response` is
+        # available.
+        # Corresponds to the JSON property `done`
+        # @return [Boolean]
+        attr_accessor :done
+        alias_method :done?, :done
+      
+        # The normal response of the operation in case of success.  If the original
+        # method returns no data on success, such as `Delete`, the response is
+        # `google.protobuf.Empty`.  If the original method is standard
+        # `Get`/`Create`/`Update`, the response should be the resource.  For other
+        # methods, the response should have the type `XxxResponse`, where `Xxx`
+        # is the original method name.  For example, if the original method name
+        # is `TakeSnapshot()`, the inferred response type is
+        # `TakeSnapshotResponse`.
+        # Corresponds to the JSON property `response`
+        # @return [Hash<String,Object>]
+        attr_accessor :response
+      
+        # The server-assigned name, which is only unique within the same service that
+        # originally returns it. If you use the default HTTP mapping, the
+        # `name` should have the format of `operations/some/unique/name`.
+        # Corresponds to the JSON property `name`
+        # @return [String]
+        attr_accessor :name
+      
+        # The `Status` type defines a logical error model that is suitable for different
+        # programming environments, including REST APIs and RPC APIs. It is used by
+        # [gRPC](https://github.com/grpc). The error model is designed to be:
+        # - Simple to use and understand for most users
+        # - Flexible enough to meet unexpected needs
+        # # Overview
+        # The `Status` message contains three pieces of data: error code, error message,
+        # and error details. The error code should be an enum value of
+        # google.rpc.Code, but it may accept additional error codes if needed.  The
+        # error message should be a developer-facing English message that helps
+        # developers *understand* and *resolve* the error. If a localized user-facing
+        # error message is needed, put the localized message in the error details or
+        # localize it in the client. The optional error details may contain arbitrary
+        # information about the error. There is a predefined set of error detail types
+        # in the package `google.rpc` that can be used for common error conditions.
+        # # Language mapping
+        # The `Status` message is the logical representation of the error model, but it
+        # is not necessarily the actual wire format. When the `Status` message is
+        # exposed in different client libraries and different wire protocols, it can be
+        # mapped differently. For example, it will likely be mapped to some exceptions
+        # in Java, but more likely mapped to some error codes in C.
+        # # Other uses
+        # The error model and the `Status` message can be used in a variety of
+        # environments, either with or without APIs, to provide a
+        # consistent developer experience across different environments.
+        # Example uses of this error model include:
+        # - Partial errors. If a service needs to return partial errors to the client,
+        # it may embed the `Status` in the normal response to indicate the partial
+        # errors.
+        # - Workflow errors. A typical workflow has multiple steps. Each step may
+        # have a `Status` message for error reporting.
+        # - Batch operations. If a client uses batch request and batch response, the
+        # `Status` message should be used directly inside batch response, one for
+        # each error sub-response.
+        # - Asynchronous operations. If an API call embeds asynchronous operation
+        # results in its response, the status of those operations should be
+        # represented directly using the `Status` message.
+        # - Logging. If some API errors are stored in logs, the message `Status` could
+        # be used directly after any stripping needed for security/privacy reasons.
+        # Corresponds to the JSON property `error`
+        # @return [Google::Apis::RuntimeconfigV1beta1::Status]
+        attr_accessor :error
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @metadata = args[:metadata] if args.key?(:metadata)
+          @done = args[:done] if args.key?(:done)
+          @response = args[:response] if args.key?(:response)
+          @name = args[:name] if args.key?(:name)
+          @error = args[:error] if args.key?(:error)
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/classes.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/representations.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/representations.rb
@@ -1,0 +1,280 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'date'
+require 'google/apis/core/base_service'
+require 'google/apis/core/json_representation'
+require 'google/apis/core/hashable'
+require 'google/apis/errors'
+
+module Google
+  module Apis
+    module RuntimeconfigV1beta1
+      
+      class SetIamPolicyRequest
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Status
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Binding
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Empty
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Cardinality
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class ListConfigsResponse
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class EndCondition
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class TestIamPermissionsResponse
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class ListVariablesResponse
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class RuntimeConfig
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class WatchVariableRequest
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class ListWaitersResponse
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class TestIamPermissionsRequest
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Waiter
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Policy
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Variable
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class Operation
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
+      class SetIamPolicyRequest
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :policy, as: 'policy', class: Google::Apis::RuntimeconfigV1beta1::Policy, decorator: Google::Apis::RuntimeconfigV1beta1::Policy::Representation
+      
+        end
+      end
+      
+      class Status
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          collection :details, as: 'details'
+          property :code, as: 'code'
+          property :message, as: 'message'
+        end
+      end
+      
+      class Binding
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          collection :members, as: 'members'
+          property :role, as: 'role'
+        end
+      end
+      
+      class Empty
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+        end
+      end
+      
+      class Cardinality
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :number, as: 'number'
+          property :path, as: 'path'
+        end
+      end
+      
+      class ListConfigsResponse
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          collection :configs, as: 'configs', class: Google::Apis::RuntimeconfigV1beta1::RuntimeConfig, decorator: Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+      
+          property :next_page_token, as: 'nextPageToken'
+        end
+      end
+      
+      class EndCondition
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :cardinality, as: 'cardinality', class: Google::Apis::RuntimeconfigV1beta1::Cardinality, decorator: Google::Apis::RuntimeconfigV1beta1::Cardinality::Representation
+      
+        end
+      end
+      
+      class TestIamPermissionsResponse
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          collection :permissions, as: 'permissions'
+        end
+      end
+      
+      class ListVariablesResponse
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :next_page_token, as: 'nextPageToken'
+          collection :variables, as: 'variables', class: Google::Apis::RuntimeconfigV1beta1::Variable, decorator: Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+      
+        end
+      end
+      
+      class RuntimeConfig
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :name, as: 'name'
+          property :description, as: 'description'
+        end
+      end
+      
+      class WatchVariableRequest
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :newer_than, as: 'newerThan'
+        end
+      end
+      
+      class ListWaitersResponse
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :next_page_token, as: 'nextPageToken'
+          collection :waiters, as: 'waiters', class: Google::Apis::RuntimeconfigV1beta1::Waiter, decorator: Google::Apis::RuntimeconfigV1beta1::Waiter::Representation
+      
+        end
+      end
+      
+      class TestIamPermissionsRequest
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          collection :permissions, as: 'permissions'
+        end
+      end
+      
+      class Waiter
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :error, as: 'error', class: Google::Apis::RuntimeconfigV1beta1::Status, decorator: Google::Apis::RuntimeconfigV1beta1::Status::Representation
+      
+          property :failure, as: 'failure', class: Google::Apis::RuntimeconfigV1beta1::EndCondition, decorator: Google::Apis::RuntimeconfigV1beta1::EndCondition::Representation
+      
+          property :success, as: 'success', class: Google::Apis::RuntimeconfigV1beta1::EndCondition, decorator: Google::Apis::RuntimeconfigV1beta1::EndCondition::Representation
+      
+          property :done, as: 'done'
+          property :create_time, as: 'createTime'
+          property :timeout, as: 'timeout'
+          property :name, as: 'name'
+        end
+      end
+      
+      class Policy
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :etag, :base64 => true, as: 'etag'
+          property :version, as: 'version'
+          collection :bindings, as: 'bindings', class: Google::Apis::RuntimeconfigV1beta1::Binding, decorator: Google::Apis::RuntimeconfigV1beta1::Binding::Representation
+      
+        end
+      end
+      
+      class Variable
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :value, :base64 => true, as: 'value'
+          property :state, as: 'state'
+          property :update_time, as: 'updateTime'
+          property :name, as: 'name'
+          property :text, as: 'text'
+        end
+      end
+      
+      class Operation
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          hash :metadata, as: 'metadata'
+          property :done, as: 'done'
+          hash :response, as: 'response'
+          property :name, as: 'name'
+          property :error, as: 'error', class: Google::Apis::RuntimeconfigV1beta1::Status, decorator: Google::Apis::RuntimeconfigV1beta1::Status::Representation
+      
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/representations.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/service.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/service.rb
@@ -1,0 +1,903 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/apis/core/base_service'
+require 'google/apis/core/json_representation'
+require 'google/apis/core/hashable'
+require 'google/apis/errors'
+
+module Google
+  module Apis
+    module RuntimeconfigV1beta1
+      # Google Cloud Runtime Configuration API
+      #
+      # The Runtime Configurator allows you to dynamically configure and expose
+      #  variables through Google Cloud Platform. In addition, you can also set
+      #  Watchers and Waiters that will watch for changes to your data and return based
+      #  on certain conditions.
+      #
+      # @example
+      #    require 'google/apis/runtimeconfig_v1beta1'
+      #
+      #    Runtimeconfig = Google::Apis::RuntimeconfigV1beta1 # Alias the module
+      #    service = Runtimeconfig::CloudRuntimeConfigService.new
+      #
+      # @see https://cloud.google.com/deployment-manager/runtime-configurator/
+      class CloudRuntimeConfigService < Google::Apis::Core::BaseService
+        # @return [String]
+        #  API key. Your API key identifies your project and provides you with API access,
+        #  quota, and reports. Required unless you provide an OAuth 2.0 token.
+        attr_accessor :key
+
+        # @return [String]
+        #  Available to use for quota purposes for server-side applications. Can be any
+        #  arbitrary string assigned to a user, but should not exceed 40 characters.
+        attr_accessor :quota_user
+
+        def initialize
+          super('https://runtimeconfig.googleapis.com/', '')
+          @batch_path = 'batch'
+        end
+        
+        # Deletes a RuntimeConfig resource.
+        # @param [String] name
+        #   The RuntimeConfig resource to delete, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Empty] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Empty]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def delete_project_config(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:delete, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Empty::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Empty
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Lists all the RuntimeConfig resources within project.
+        # @param [String] parent
+        #   The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&
+        #   ref_topic=6158848)
+        #   for this request, in the format `projects/[PROJECT_ID]`.
+        # @param [String] page_token
+        #   Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+        #   returned by a previous list request to get the next page of results.
+        # @param [Fixnum] page_size
+        #   Specifies the number of results to return per page. If there are fewer
+        #   elements than the specified number, returns all elements.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::ListConfigsResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::ListConfigsResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def list_project_configs(parent, page_token: nil, page_size: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+parent}/configs', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::ListConfigsResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::ListConfigsResponse
+          command.params['parent'] = parent unless parent.nil?
+          command.query['pageToken'] = page_token unless page_token.nil?
+          command.query['pageSize'] = page_size unless page_size.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Sets the access control policy on the specified resource. Replaces any
+        # existing policy.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy is being specified.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [Google::Apis::RuntimeconfigV1beta1::SetIamPolicyRequest] set_iam_policy_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Policy] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Policy]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def set_config_iam_policy(resource, set_iam_policy_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+resource}:setIamPolicy', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::SetIamPolicyRequest::Representation
+          command.request_object = set_iam_policy_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Policy::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Policy
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Creates a new RuntimeConfig resource. The configuration name must be
+        # unique within project.
+        # @param [String] parent
+        #   The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&
+        #   ref_topic=6158848)
+        #   for this request, in the format `projects/[PROJECT_ID]`.
+        # @param [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig] runtime_config_object
+        # @param [String] request_id
+        #   An optional but recommended unique `request_id`. If the server
+        #   receives two `create()` requests  with the same
+        #   `request_id`, then the second request will be ignored and the
+        #   first resource created and stored in the backend is returned.
+        #   Empty `request_id` fields are ignored.
+        #   It is responsibility of the client to ensure uniqueness of the
+        #   `request_id` strings.
+        #   `request_id` strings are limited to 64 characters.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def create_project_config(parent, runtime_config_object = nil, request_id: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+parent}/configs', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+          command.request_object = runtime_config_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig
+          command.params['parent'] = parent unless parent.nil?
+          command.query['requestId'] = request_id unless request_id.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Gets the access control policy for a resource.
+        # Returns an empty policy if the resource exists and does not have a policy
+        # set.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy is being requested.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Policy] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Policy]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def get_project_config_iam_policy(resource, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+resource}:getIamPolicy', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Policy::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Policy
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Gets information about a RuntimeConfig resource.
+        # @param [String] name
+        #   The name of the RuntimeConfig resource to retrieve, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def get_project_config(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Updates a RuntimeConfig resource. The configuration must exist beforehand.
+        # @param [String] name
+        #   The name of the RuntimeConfig resource to update, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig] runtime_config_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::RuntimeConfig]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def update_project_config(name, runtime_config_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:put, 'v1beta1/{+name}', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+          command.request_object = runtime_config_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::RuntimeConfig
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Returns permissions that a caller has on the specified resource.
+        # If the resource does not exist, this will return an empty set of
+        # permissions, not a NOT_FOUND error.
+        # Note: This operation is designed to be used for building permission-aware
+        # UIs and command-line tools, not for authorization checking. This operation
+        # may "fail open" without warning.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy detail is being requested.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest] test_iam_permissions_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def test_config_iam_permissions(resource, test_iam_permissions_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+resource}:testIamPermissions', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest::Representation
+          command.request_object = test_iam_permissions_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Gets information about a single variable.
+        # @param [String] name
+        #   The name of the variable to return, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIBLE_NAME]`
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Variable] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Variable]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def get_project_config_variable(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Variable
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Watches a specific variable and waits for a change in the variable's value.
+        # When there is a change, this method returns the new value or times out.
+        # If a variable is deleted while being watched, the `variableState` state is
+        # set to `DELETED` and the method returns the last known variable `value`.
+        # If you set the deadline for watching to a larger value than internal timeout
+        # (60 seconds), the current variable value is returned and the `variableState`
+        # will be `VARIABLE_STATE_UNSPECIFIED`.
+        # To learn more about creating a watcher, read the
+        # [Watching a Variable for Changes](/deployment-manager/runtime-configurator/
+        # watching-a-variable)
+        # documentation.
+        # @param [String] name
+        #   The name of the variable to watch, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [Google::Apis::RuntimeconfigV1beta1::WatchVariableRequest] watch_variable_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Variable] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Variable]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def watch_variable(name, watch_variable_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+name}:watch', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::WatchVariableRequest::Representation
+          command.request_object = watch_variable_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Variable
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Updates an existing variable with a new value.
+        # @param [String] name
+        #   The name of the variable to update, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+        # @param [Google::Apis::RuntimeconfigV1beta1::Variable] variable_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Variable] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Variable]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def update_project_config_variable(name, variable_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:put, 'v1beta1/{+name}', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.request_object = variable_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Variable
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Returns permissions that a caller has on the specified resource.
+        # If the resource does not exist, this will return an empty set of
+        # permissions, not a NOT_FOUND error.
+        # Note: This operation is designed to be used for building permission-aware
+        # UIs and command-line tools, not for authorization checking. This operation
+        # may "fail open" without warning.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy detail is being requested.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest] test_iam_permissions_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def test_variable_iam_permissions(resource, test_iam_permissions_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+resource}:testIamPermissions', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest::Representation
+          command.request_object = test_iam_permissions_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Deletes a variable or multiple variables.
+        # If you specify a variable name, then that variable is deleted. If you
+        # specify a prefix and `recursive` is true, then all variables with that
+        # prefix are deleted. You must set a `recursive` to true if you delete
+        # variables by prefix.
+        # @param [String] name
+        #   The name of the variable to delete, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+        # @param [Boolean] recursive
+        #   Set to `true` to recursively delete multiple variables with the same
+        #   prefix.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Empty] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Empty]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def delete_project_config_variable(name, recursive: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:delete, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Empty::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Empty
+          command.params['name'] = name unless name.nil?
+          command.query['recursive'] = recursive unless recursive.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Lists variables within given a configuration, matching any provided filters.
+        # This only lists variable names, not the values, unless `return_values` is
+        # true, in which case only variables that user has IAM permission to GetVariable
+        # will be returned.
+        # @param [String] parent
+        #   The path to the RuntimeConfig resource for which you want to list variables.
+        #   The configuration must exist beforehand; the path must by in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [String] filter
+        #   Filters variables by matching the specified filter. For example:
+        #   `projects/example-project/config/[CONFIG_NAME]/variables/example-variable`.
+        # @param [Boolean] return_values
+        #   The flag indicates whether the user wants to return values of variables.
+        #   If true, then only those variables that user has IAM GetVariable permission
+        #   will be returned along with their values.
+        # @param [String] page_token
+        #   Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+        #   returned by a previous list request to get the next page of results.
+        # @param [Fixnum] page_size
+        #   Specifies the number of results to return per page. If there are fewer
+        #   elements than the specified number, returns all elements.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::ListVariablesResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::ListVariablesResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def list_project_config_variables(parent, filter: nil, return_values: nil, page_token: nil, page_size: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+parent}/variables', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::ListVariablesResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::ListVariablesResponse
+          command.params['parent'] = parent unless parent.nil?
+          command.query['filter'] = filter unless filter.nil?
+          command.query['returnValues'] = return_values unless return_values.nil?
+          command.query['pageToken'] = page_token unless page_token.nil?
+          command.query['pageSize'] = page_size unless page_size.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Creates a variable within the given configuration. You cannot create
+        # a variable with a name that is a prefix of an existing variable name, or a
+        # name that has an existing variable name as a prefix.
+        # To learn more about creating a variable, read the
+        # [Setting and Getting Data](/deployment-manager/runtime-configurator/set-and-
+        # get-variables)
+        # documentation.
+        # @param [String] parent
+        #   The path to the RutimeConfig resource that this variable should belong to.
+        #   The configuration must exist beforehand; the path must by in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [Google::Apis::RuntimeconfigV1beta1::Variable] variable_object
+        # @param [String] request_id
+        #   An optional but recommended unique `request_id`. If the server
+        #   receives two `create()` requests  with the same
+        #   `request_id`, then the second request will be ignored and the
+        #   first resource created and stored in the backend is returned.
+        #   Empty `request_id` fields are ignored.
+        #   It is responsibility of the client to ensure uniqueness of the
+        #   `request_id` strings.
+        #   `request_id` strings are limited to 64 characters.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Variable] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Variable]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def create_project_config_variable(parent, variable_object = nil, request_id: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+parent}/variables', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.request_object = variable_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Variable::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Variable
+          command.params['parent'] = parent unless parent.nil?
+          command.query['requestId'] = request_id unless request_id.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Creates a Waiter resource. This operation returns a long-running Operation
+        # resource which can be polled for completion. However, a waiter with the
+        # given name will exist (and can be retrieved) prior to the operation
+        # completing. If the operation fails, the failed Waiter resource will
+        # still exist and must be deleted prior to subsequent creation attempts.
+        # @param [String] parent
+        #   The path to the configuration that will own the waiter.
+        #   The configuration must exist beforehand; the path must by in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`.
+        # @param [Google::Apis::RuntimeconfigV1beta1::Waiter] waiter_object
+        # @param [String] request_id
+        #   An optional but recommended unique `request_id`. If the server
+        #   receives two `create()` requests  with the same
+        #   `request_id`, then the second request will be ignored and the
+        #   first resource created and stored in the backend is returned.
+        #   Empty `request_id` fields are ignored.
+        #   It is responsibility of the client to ensure uniqueness of the
+        #   `request_id` strings.
+        #   `request_id` strings are limited to 64 characters.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Operation] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Operation]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def create_project_config_waiter(parent, waiter_object = nil, request_id: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+parent}/waiters', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::Waiter::Representation
+          command.request_object = waiter_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Operation::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Operation
+          command.params['parent'] = parent unless parent.nil?
+          command.query['requestId'] = request_id unless request_id.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Returns permissions that a caller has on the specified resource.
+        # If the resource does not exist, this will return an empty set of
+        # permissions, not a NOT_FOUND error.
+        # Note: This operation is designed to be used for building permission-aware
+        # UIs and command-line tools, not for authorization checking. This operation
+        # may "fail open" without warning.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy detail is being requested.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest] test_iam_permissions_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def test_waiter_iam_permissions(resource, test_iam_permissions_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+resource}:testIamPermissions', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest::Representation
+          command.request_object = test_iam_permissions_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Deletes the waiter with the specified name.
+        # @param [String] name
+        #   The Waiter resource to delete, in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Empty] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Empty]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def delete_project_config_waiter(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:delete, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Empty::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Empty
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Gets information about a single waiter.
+        # @param [String] name
+        #   The fully-qualified name of the Waiter resource object to retrieve, in the
+        #   format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Waiter] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Waiter]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def get_project_config_waiter(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Waiter::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Waiter
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # List waiters within the given configuration.
+        # @param [String] parent
+        #   The path to the configuration for which you want to get a list of waiters.
+        #   The configuration must exist beforehand; the path must by in the format:
+        #   `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+        # @param [String] page_token
+        #   Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+        #   returned by a previous list request to get the next page of results.
+        # @param [Fixnum] page_size
+        #   Specifies the number of results to return per page. If there are fewer
+        #   elements than the specified number, returns all elements.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::ListWaitersResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::ListWaitersResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def list_project_config_waiters(parent, page_token: nil, page_size: nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+parent}/waiters', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::ListWaitersResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::ListWaitersResponse
+          command.params['parent'] = parent unless parent.nil?
+          command.query['pageToken'] = page_token unless page_token.nil?
+          command.query['pageSize'] = page_size unless page_size.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Gets the latest state of a long-running operation.  Clients can use this
+        # method to poll the operation result at intervals as recommended by the API
+        # service.
+        # @param [String] name
+        #   The name of the operation resource.
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::Operation] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::Operation]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def get_project_config_operation(name, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:get, 'v1beta1/{+name}', options)
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::Operation::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::Operation
+          command.params['name'] = name unless name.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+        
+        # Returns permissions that a caller has on the specified resource.
+        # If the resource does not exist, this will return an empty set of
+        # permissions, not a NOT_FOUND error.
+        # Note: This operation is designed to be used for building permission-aware
+        # UIs and command-line tools, not for authorization checking. This operation
+        # may "fail open" without warning.
+        # @param [String] resource
+        #   REQUIRED: The resource for which the policy detail is being requested.
+        #   See the operation documentation for the appropriate value for this field.
+        # @param [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest] test_iam_permissions_request_object
+        # @param [String] fields
+        #   Selector specifying which fields to include in a partial response.
+        # @param [String] quota_user
+        #   Available to use for quota purposes for server-side applications. Can be any
+        #   arbitrary string assigned to a user, but should not exceed 40 characters.
+        # @param [Google::Apis::RequestOptions] options
+        #   Request-specific options
+        #
+        # @yield [result, err] Result & error if block supplied
+        # @yieldparam result [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse] parsed result object
+        # @yieldparam err [StandardError] error object if request failed
+        #
+        # @return [Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse]
+        #
+        # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
+        # @raise [Google::Apis::ClientError] The request is invalid and should not be retried without modification
+        # @raise [Google::Apis::AuthorizationError] Authorization is required
+        def test_operation_iam_permissions(resource, test_iam_permissions_request_object = nil, fields: nil, quota_user: nil, options: nil, &block)
+          command =  make_simple_command(:post, 'v1beta1/{+resource}:testIamPermissions', options)
+          command.request_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsRequest::Representation
+          command.request_object = test_iam_permissions_request_object
+          command.response_representation = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse::Representation
+          command.response_class = Google::Apis::RuntimeconfigV1beta1::TestIamPermissionsResponse
+          command.params['resource'] = resource unless resource.nil?
+          command.query['fields'] = fields unless fields.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+          execute_or_queue_command(command, &block)
+        end
+
+        protected
+
+        def apply_command_defaults(command)
+          command.query['key'] = key unless key.nil?
+          command.query['quotaUser'] = quota_user unless quota_user.nil?
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/service.rb
+++ b/ruby/lib/rcloadenv/google/apis/runtimeconfig_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ruby/lib/rcloadenv/loader.rb
+++ b/ruby/lib/rcloadenv/loader.rb
@@ -1,0 +1,153 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "rcloadenv/api_client"
+require "google/cloud/env"
+
+module RCLoadEnv
+
+  ##
+  # A class that loads environment variables from a RuntimeConfig resource.
+  #
+  class Loader
+
+    ##
+    # Error thrown when inputs are malformed.
+    #
+    class UsageError < StandardError
+    end
+
+    ##
+    # Create a loader. Alwaus uses application default credentials.
+    #
+    # @param [String] config_name Name of the runtime config resource
+    # @param [String,nil] project Optional name of the cloud project. If not
+    #     set, attempts to infer one from the environment.
+    #
+    def initialize config_name,
+                   exclude: nil, include: nil, override: false,
+                   project: nil, debug: false
+      @config_name = config_name.to_s
+      @project = (project || default_project).to_s
+      @exclude = exclude
+      @include = include
+      @override = override
+      @debug = debug
+    end
+
+    ## @return [String] The Runtime Config resource name
+    attr_reader :config_name
+    ## @return [String] The cloud project
+    attr_reader :project
+
+    ##
+    # Modify the given environment with the configuration. The given hash
+    # is modified in place. If no hash is provided, a new one is created
+    # and returned.
+    #
+    # @param [Hash<String,String>] env The environment to modify.
+    # @return the environment.
+    #
+    def modify_env env={}
+      raw_variables.each do |k, v|
+        if !@exclude.empty? && @exclude.include?(k) ||
+           !@include.empty? && !@include.include?(k)
+          debug "Skipping config variable #{k}"
+        else
+          debug "Found config variable #{k}"
+          key = k.split("/").last.upcase.gsub("-", "_")
+          if !env.include?(key)
+            debug "Setting envvar: #{key}"
+            env[key] = v
+          elsif @override
+            debug "Overriding envvar: #{key}"
+            env[key] = v
+          else
+            debug "Envvar already set: #{key}"
+          end
+        end
+      end
+      env
+    end
+
+    ##
+    # Returns the has of variables retrieved from the runtime config.
+    # Variable names have the parent (project and config name) stripped.
+    # Values are all converted to strings.
+    #
+    # @return [Hash<String,String>] the variables.
+    #
+    def raw_variables
+      @raw_variables ||= load_raw_variables
+    end
+
+    ## @private
+    def service
+      @service ||= create_service
+    end
+
+    ## @private
+    def service= mock
+      @service = mock
+    end
+
+    ## @private
+    def load_raw_variables
+      if project.empty?
+        raise UsageError, "Project name must be provided."
+      end
+      if config_name.empty?
+        raise UsageError, "Config name must be provided."
+      end
+      parent_path = "projects/#{project}/configs/#{config_name}"
+      debug "Loading #{config_name} from project #{project}"
+      response = service.list_project_config_variables \
+        parent_path, return_values: true
+      raw_variables = {}
+      (response.to_h[:variables] || []).each do |var_info|
+        key = var_info[:name].sub "#{parent_path}/variables/", ""
+        raw_variables[key] = var_info[:text] || var_info[:value]
+      end
+      raw_variables
+    end
+
+    ## @private
+    def default_project
+      ENV["GOOGLE_CLOUD_PROJECT"] ||
+        ENV["GCLOUD_PROJECT"] ||
+        Google::Cloud.env.project_id ||
+        `gcloud config get-value project 2>/dev/null`.strip
+    end
+
+    ## @private
+    def create_service
+      s = Google::Apis::RuntimeconfigV1beta1::CloudRuntimeConfigService.new
+      s.client_options.application_name = "rcloadenv-ruby"
+      s.client_options.application_version = RCLoadEnv::VERSION
+      s.request_options.retries = 3
+      s.request_options.header ||= {}
+      s.request_options.header["x-goog-api-client"] = \
+        "gl-ruby/#{RUBY_VERSION} rcloadenv/#{RCLoadEnv::VERSION}"
+      s.authorization = RCLoadEnv::Credentials.default.client
+      s
+    end
+
+    ## @private
+    def debug str
+      STDERR.puts "RCLOADENV DEBUG: #{str}" if @debug
+    end
+  end
+
+end

--- a/ruby/lib/rcloadenv/loader.rb
+++ b/ruby/lib/rcloadenv/loader.rb
@@ -33,11 +33,16 @@ module RCLoadEnv
     # Create a loader. Alwaus uses application default credentials.
     #
     # @param [String] config_name Name of the runtime config resource
+    # @param [Array<String>] exclude Config keys to exclude (optional)
+    # @param [Array<String>] include Config keys to include (optional)
+    # @param [Boolean] override Whether to override existing environment
+    #     variables (default: false)
     # @param [String,nil] project Optional name of the cloud project. If not
     #     set, attempts to infer one from the environment.
+    # @param [Boolean] debug Whether to print debug output (default: false)
     #
     def initialize config_name,
-                   exclude: nil, include: nil, override: false,
+                   exclude: [], include: [], override: false,
                    project: nil, debug: false
       @config_name = config_name.to_s
       @project = (project || default_project).to_s
@@ -54,11 +59,11 @@ module RCLoadEnv
 
     ##
     # Modify the given environment with the configuration. The given hash
-    # is modified in place. If no hash is provided, a new one is created
-    # and returned.
+    # is modified in place and returned. If no hash is provided, a new one is
+    # created and returned.
     #
     # @param [Hash<String,String>] env The environment to modify.
-    # @return the environment.
+    # @return the modified environment.
     #
     def modify_env env={}
       raw_variables.each do |k, v|
@@ -98,7 +103,7 @@ module RCLoadEnv
       @service ||= create_service
     end
 
-    ## @private
+    ## @private Used to mock the service for testing
     def service= mock
       @service = mock
     end

--- a/ruby/lib/rcloadenv/version.rb
+++ b/ruby/lib/rcloadenv/version.rb
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+module RCLoadEnv
+
+  ## The current version of this gem, as a string.
+  VERSION = '0.1.0'.freeze
+
+end

--- a/ruby/rcloadenv.gemspec
+++ b/ruby/rcloadenv.gemspec
@@ -1,0 +1,51 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+lib = File.expand_path "../lib", __FILE__
+$LOAD_PATH.unshift lib unless $LOAD_PATH.include? lib
+require 'rcloadenv/version'
+
+::Gem::Specification.new do |spec|
+  spec.name = "rcloadenv"
+  spec.version = ::RCLoadEnv::VERSION
+  spec.authors = ["Daniel Azuma"]
+  spec.email = ["dazuma@gmail.com"]
+
+  spec.summary = "Load Google Runtime Config data into environment variables"
+  spec.description = "rcloadenv is a tool for loading configuration from the" \
+    " Google Runtime Config API into environment variables. The rcloadenv" \
+    " ruby gem is a ruby implementation of the tool that may be installed as" \
+    " a ruby gem or included in a ruby Gemfile."
+  spec.license = "Apache 2.0"
+  spec.homepage = "https://github.com/GoogleCloudPlatform/rcloadenv"
+
+  spec.files = ::Dir.glob("lib/**/*.rb") + ::Dir.glob("*.md") +
+    [".yardopts", "bin/rcloadenv"]
+  spec.required_ruby_version = ">= 2.0.0"
+  spec.require_paths = ["lib"]
+
+  spec.bindir = "bin"
+  spec.executables = ["rcloadenv"]
+
+  spec.add_dependency "google-api-client", "~> 0.5"
+  spec.add_dependency "google-cloud-core", "~> 1.0"
+  spec.add_dependency "google-cloud-env", "~> 1.0"
+
+  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 11.0"
+  spec.add_development_dependency "rdoc", "~> 4.2"
+  spec.add_development_dependency "yard", "~> 0.9"
+end

--- a/ruby/rcloadenv.gemspec
+++ b/ruby/rcloadenv.gemspec
@@ -39,7 +39,7 @@ require 'rcloadenv/version'
   spec.bindir = "bin"
   spec.executables = ["rcloadenv"]
 
-  spec.add_dependency "google-api-client", "~> 0.5"
+  spec.add_dependency "google-api-client", "~> 0.13"
   spec.add_dependency "google-cloud-core", "~> 1.0"
   spec.add_dependency "google-cloud-env", "~> 1.0"
 

--- a/ruby/test/test_loader.rb
+++ b/ruby/test/test_loader.rb
@@ -1,0 +1,111 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+;
+
+require "minitest/autorun"
+require "rcloadenv"
+
+module RCLoadEnv
+  module Tests  # :nodoc:
+
+    class TestLoader < ::Minitest::Test  # :nodoc:
+
+      PROJECT = "my-project"
+      CONFIG = "my-config"
+
+      def setup_loader opts={}
+        loader = Loader.new CONFIG, opts.merge(project: PROJECT)
+        mock = Minitest::Mock.new
+        mock.expect :list_project_config_variables,
+          {
+            variables: [
+              {name: "var1", value: "binval"},
+              {name: "var2", text: "txtval"},
+              {name: "long/path/name", value: "value3"},
+              {name: "Name-With-Dashes", value: "value4"}
+            ]
+          },
+          ["projects/#{PROJECT}/configs/#{CONFIG}", {return_values: true}]
+        loader.service = mock
+        result = yield loader
+        mock.verify
+        result
+      end
+
+      def test_transforms
+        setup_loader do |loader|
+          expected_env = {
+            "VAR1" => "binval",
+            "VAR2" => "txtval",
+            "NAME" => "value3",
+            "NAME_WITH_DASHES" => "value4"
+          }
+          assert_equal expected_env, loader.modify_env
+        end
+      end
+
+      def test_exclude
+        setup_loader exclude: ["var1", "VAR2", "long/path/name"] do |loader|
+          expected_env = {
+            "VAR2" => "txtval",
+            "NAME_WITH_DASHES" => "value4"
+          }
+          assert_equal expected_env, loader.modify_env
+        end
+      end
+
+      def test_include
+        setup_loader include: ["var1", "VAR2", "long/path/name"] do |loader|
+          expected_env = {
+            "VAR1" => "binval",
+            "NAME" => "value3",
+          }
+          assert_equal expected_env, loader.modify_env
+        end
+      end
+
+      def test_no_override
+        setup_loader do |loader|
+          env = {
+            "VAR1" => "original"
+          }
+          expected_env = {
+            "VAR1" => "original",
+            "VAR2" => "txtval",
+            "NAME" => "value3",
+            "NAME_WITH_DASHES" => "value4"
+          }
+          assert_equal expected_env, loader.modify_env(env)
+        end
+      end
+
+      def test_override
+        setup_loader override: true do |loader|
+          env = {
+            "VAR1" => "original"
+          }
+          expected_env = {
+            "VAR1" => "binval",
+            "VAR2" => "txtval",
+            "NAME" => "value3",
+            "NAME_WITH_DASHES" => "value4"
+          }
+          assert_equal expected_env, loader.modify_env(env)
+        end
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
This is a full Ruby implementation of rcloadenv, ready for release as a rubygem. It is provided for easy integration with Ruby applications, in particular to support "secrets" configured for Ruby applications deployed to GCP.

Notes:

* The implementation passes the provided cross-language integration test.
* The Ruby-based binary understands the same command line switches as the nodejs binary.
* The code includes a vendored API client for the runtimeconfig API version v1beta1. This is because this API is not currently included in the canonical google-api-client gem. The code looks for a canonical client before using the vendored client.