### PR TITLE
Rerelease Ruby with fixed file permissions

### DIFF
--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Ruby rcloadenv
 
+## v0.1.1 / 2017-09-11
+
+*   Fix file permissions.
+
 ## v0.1.0 / 2017-08-10
 
 *   Initial implementation; parallels the nodejs implementation features

--- a/ruby/lib/rcloadenv/version.rb
+++ b/ruby/lib/rcloadenv/version.rb
@@ -16,6 +16,6 @@
 module RCLoadEnv
 
   ## The current version of this gem, as a string.
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 
 end


### PR DESCRIPTION
Bumping the Ruby library version for a rerelease with fixed file permissions. The 0.1.0 gem has ruby files with permission 0640 instead of 0644.