### PR TITLE
Implement override guard in NodeJS implementation

### DIFF
--- a/nodejs/bin/rcloadenv
+++ b/nodejs/bin/rcloadenv
@@ -44,7 +44,7 @@ const cli = exports.cli = require('yargs')
     },
     override: {
       alias: 'o',
-      default: true,
+      default: false,
       description: 'Determines the behavior of rcloadenv in the case when a runtime-config variable conflicts with a variable already available in the environment. If true, a runtime-config variable will override the existing environment variable, otherwise the existing environment variable will be kept.',
       type: 'boolean'
     },

--- a/nodejs/src/index.js
+++ b/nodejs/src/index.js
@@ -96,7 +96,7 @@ exports.getVariables = (configName, opts = {}) => {
  * @param {object[]} variables
  * @param {object} [opts]
  */
-exports.transform = (variables, opts = {}) => {
+exports.transform = (variables, oldEnv, opts = {}) => {
   const env = {};
 
   opts.only || (opts.only = []);
@@ -122,7 +122,13 @@ exports.transform = (variables, opts = {}) => {
       value = Buffer.from(variable.value, 'base64').toString();
     }
 
-    env[snakeCase(name).toUpperCase()] = env[name] = value;
+    const upperName = snakeCase(name).toUpperCase();
+    if (opts.override || !oldEnv[name]) {
+      env[name] = value;
+    }
+    if (opts.override || !oldEnv[upperName]) {
+      env[upperName] = value;
+    }
   });
 
   return env;
@@ -136,7 +142,7 @@ exports.transform = (variables, opts = {}) => {
  * @param {object} [opts]
  */
 exports.apply = (variables, env = process.env, opts = {}) => {
-  return Object.assign(env, exports.transform(variables, opts));
+  return Object.assign(env, exports.transform(variables, env, opts));
 };
 
 /**

--- a/nodejs/src/index.js
+++ b/nodejs/src/index.js
@@ -94,9 +94,10 @@ exports.getVariables = (configName, opts = {}) => {
  * Out: { VAR1: "...", VAR2: "...", ... }
  *
  * @param {object[]} variables
+ * @param {object} [oldEnv]
  * @param {object} [opts]
  */
-exports.transform = (variables, oldEnv, opts = {}) => {
+exports.transform = (variables, oldEnv = {}, opts = {}) => {
   const env = {};
 
   opts.only || (opts.only = []);


### PR DESCRIPTION
The CircleCI tests have been failing for the NodeJS implementation because it hasn't been implementing the correct "override" behavior defined by the test: if a runtime-config variable conflicts with an existing environment variable, the existing variable should be preserved. This PR fixes that issue. It also completes what appears to have been the original intent of the NodeJS implementation to provide an `--override` flag that controls the policy.