### PR TITLE
Output dotenv format if no command is given

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -14,10 +14,26 @@ Install the gem using
 Alternately, include "rcloadenv" in your application's Gemfile.
 
 You may then invoke the "rcloadenv" binary. You must pass the name of the
-runtime config resource, and then the command to execute. For example, if
-the gem is present in the bundle for your Rails app, you can execute:
+runtime config resource, and then optionally a command to execute, delimited
+by two dashes `--`.
+
+If a command is provided, rcloadenv loads the configuration into environment
+variables and runs the command. For example, if the gem is present in the
+bundle for your Rails app, you can execute:
 
     bundle exec rcloadenv my-config -- bin/rails s
+
+to run Rails directly with the loaded environment.
+
+If a command is _not_ provided_, rcloadenv loads the configuration and prints
+it to stdout in dotenv-compatible format. For example, you can execute:
+
+    bundle exec rcloadenv my-config > .env
+
+to create a `.env` file suitable for loading with the
+[dotenv](https://github.com/bkeepers/dotenv/) gem.
+
+### Accessing runtime config data
 
 If `rcloadenv` is run on Google Cloud Platform hosting (such as Google Compute
 Engine, Container Engine, or App Engine), then it infers the project name and
@@ -34,7 +50,7 @@ Run `rcloadenv --help` for more information on flags you can set.
 When not running on GCP, credentials are obtained from
 [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials),
 so you can set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or
-configure `gcloud auth`.
+configure `gcloud auth application-default login`.
 
 ## Example: Loading the Rails SECRET_KEY_BASE in Google App Engine
 

--- a/ruby/rcloadenv.gemspec
+++ b/ruby/rcloadenv.gemspec
@@ -48,4 +48,5 @@ require 'rcloadenv/version'
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rdoc", "~> 4.2"
   spec.add_development_dependency "yard", "~> 0.9"
+  spec.add_development_dependency "dotenv", "~> 2.2"
 end


### PR DESCRIPTION
This is a feature proposal, implemented only in the Ruby version for now.

Instead of loading the environment at application startup, I would like to use rcloadenv as an application build step to create a `.env` file that can be embedded in a build artifact and loaded at runtime using a tool such as [dotenv](https://github.com/bkeepers/dotenv/).

To that end, I propose that, if no command is provided on the command line, dotenv-compatible output should be written to stdout. Thus, the following could be executed during a build:

    rcloadenv my-config-name > .env

This is not a breaking change because rcloadenv currently exits with an error if no command is given.

(A future extension could allow specifying an output file on the command line without using redirects; e.g. `--output=.env`. However, some implementations, such as Ruby and Node, already reserve `-o` and `-O` for other flags related to overrides and key selection, so a flag name would have to be chosen carefully. Hence, this PR punts on that issue and writes only to the standard streams.)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
